### PR TITLE
Add check if service was reported to be supported

### DIFF
--- a/components/taixia/climate/taixia_climate.cpp
+++ b/components/taixia/climate/taixia_climate.cpp
@@ -303,26 +303,34 @@ using namespace esphome::climate;
           swing_vertical = 0x00;          // turn off vertical swing
           break;
       }
-      // send all swing settings
-      command[2] = WRITE | SERVICE_ID_CLIMATE_SWING_HORIZONTAL;
-      command[4] = swing_horizontal;
-      command[5] = this->parent_->checksum(command, 5);
-      this->parent_->send_cmd(command, buffer, 6);
+      // send all supported swing settings
+      if (this->parent_->get_supported_service_info_(SERVICE_ID_CLIMATE_SWING_HORIZONTAL, 0, 0, 0) > 0) {
+        command[2] = WRITE | SERVICE_ID_CLIMATE_SWING_HORIZONTAL;
+        command[4] = swing_horizontal;
+        command[5] = this->parent_->checksum(command, 5);
+        this->parent_->send_cmd(command, buffer, 6);
+      }
 
-      command[2] = WRITE | SERVICE_ID_CLIMATE_SWING_HORIZONTAL_LEVEL;
-      command[4] = swing_horizontal_level;
-      command[5] = this->parent_->checksum(command, 5);
-      this->parent_->send_cmd(command, buffer, 6);
+      if (this->parent_->get_supported_service_info_(SERVICE_ID_CLIMATE_SWING_HORIZONTAL_LEVEL, 0, 0, 0) > 0) {
+        command[2] = WRITE | SERVICE_ID_CLIMATE_SWING_HORIZONTAL_LEVEL;
+        command[4] = swing_horizontal_level;
+        command[5] = this->parent_->checksum(command, 5);
+        this->parent_->send_cmd(command, buffer, 6);
+      }
 
-      command[2] = WRITE | SERVICE_ID_CLIMATE_SWING_VERTICAL;
-      command[4] = swing_vertical;
-      command[5] = this->parent_->checksum(command, 5);
-      this->parent_->send_cmd(command, buffer, 6);
+      if (this->parent_->get_supported_service_info_(SERVICE_ID_CLIMATE_SWING_VERTICAL, 0, 0, 0) > 0) {
+        command[2] = WRITE | SERVICE_ID_CLIMATE_SWING_VERTICAL;
+        command[4] = swing_vertical;
+        command[5] = this->parent_->checksum(command, 5);
+        this->parent_->send_cmd(command, buffer, 6);
+      }
 
-      // command[2] = WRITE | SERVICE_ID_CLIMATE_SWING_VERTICAL_LEVEL;
-      // command[4] = swing_vertical_level;
-      // command[5] = this->parent_->checksum(command, 5);
-      // this->parent_->send_cmd(command, buffer, 6);
+      if (this->parent_->get_supported_service_info_(SERVICE_ID_CLIMATE_SWING_VERTICAL_LEVEL, 0, 0, 0) > 0) {
+        command[2] = WRITE | SERVICE_ID_CLIMATE_SWING_VERTICAL_LEVEL;
+        command[4] = swing_vertical_level;
+        command[5] = this->parent_->checksum(command, 5);
+        this->parent_->send_cmd(command, buffer, 6);
+      }
     }
     this->publish_state();
     if (this->parent_->get_version() < 3.0)
@@ -468,13 +476,6 @@ using namespace esphome::climate;
     uint8_t swing_vertical_level = -1;
     uint8_t swing_horizontal = 0;
     uint8_t swing_horizontal_level = -1;
-    /* 0: swing
-     * 1: ----\\ stationary right
-     * 2: ---\-- stationary center-right
-     * 3: --||-- stationary center
-     * 4: --/--- stationary center-left
-     * 5: //---- stationary left
-     */
 
     ESP_LOGV(TAG, " handle_response %x %x %x %x %x %x %x %x %x", \
         response[0], response[1], response[2], response[3], \
@@ -558,11 +559,11 @@ using namespace esphome::climate;
           break;
         case SERVICE_ID_CLIMATE_SWING_VERTICAL:
           value = get_u16(response, i + 1);
-          ESP_LOGV(
-              TAG,
-              "SERVICE_ID_CLIMATE_SWING_VERTICAL(%2.2x): %2.2d",
-              SERVICE_ID_CLIMATE_SWING_VERTICAL,
-              value);
+          // ESP_LOGV(
+          //     TAG,
+          //     "SERVICE_ID_CLIMATE_SWING_VERTICAL(%2.2x): %2.2d",
+          //     SERVICE_ID_CLIMATE_SWING_VERTICAL,
+          //     value);
           if (swing_vertical_level != -1) {
             if (value >= 1)
               swing_vertical = 1;
@@ -576,11 +577,11 @@ using namespace esphome::climate;
           break;
         case SERVICE_ID_CLIMATE_SWING_VERTICAL_LEVEL:
           value = get_u16(response, i + 1);
-          ESP_LOGV(
-            TAG,
-            "SERVICE_ID_CLIMATE_SWING_VERTICAL_LEVEL(%2.2x): %2.2d",
-            SERVICE_ID_CLIMATE_SWING_VERTICAL_LEVEL,
-            value);
+          // ESP_LOGV(
+          //   TAG,
+          //   "SERVICE_ID_CLIMATE_SWING_VERTICAL_LEVEL(%2.2x): %2.2d",
+          //   SERVICE_ID_CLIMATE_SWING_VERTICAL_LEVEL,
+          //   value);
           swing_vertical_level = (uint8_t)(value & 0xFF);
           if (swing_vertical_level == 0) {
             swing_vertical = 1;
@@ -590,11 +591,11 @@ using namespace esphome::climate;
           break;
         case SERVICE_ID_CLIMATE_SWING_HORIZONTAL:
           value = get_u16(response, i + 1);
-          ESP_LOGV(
-            TAG,
-            "SERVICE_ID_CLIMATE_SWING_HORIZONTAL(%2.2x): %2.2d",
-            SERVICE_ID_CLIMATE_SWING_HORIZONTAL,
-            value);
+          // ESP_LOGV(
+          //   TAG,
+          //   "SERVICE_ID_CLIMATE_SWING_HORIZONTAL(%2.2x): %2.2d",
+          //   SERVICE_ID_CLIMATE_SWING_HORIZONTAL,
+          //   value);
           if (swing_horizontal_level != -1) {
             if (value >= 1)
               swing_horizontal = 1;
@@ -608,11 +609,11 @@ using namespace esphome::climate;
           break;
         case SERVICE_ID_CLIMATE_SWING_HORIZONTAL_LEVEL:
           value = get_u16(response, i + 1);
-          ESP_LOGV(
-            TAG,
-            "SERVICE_ID_CLIMATE_SWING_HORIZONTAL_LEVEL(%2.2x): %2.2d",
-            SERVICE_ID_CLIMATE_SWING_HORIZONTAL_LEVEL,
-            value);
+          // ESP_LOGV(
+          //   TAG,
+          //   "SERVICE_ID_CLIMATE_SWING_HORIZONTAL_LEVEL(%2.2x): %2.2d",
+          //   SERVICE_ID_CLIMATE_SWING_HORIZONTAL_LEVEL,
+          //   value);
           swing_horizontal_level = (uint8_t)(value & 0xFF);
           if (swing_horizontal_level == 0) {
             swing_horizontal = 1;

--- a/components/taixia/taixia.h
+++ b/components/taixia/taixia.h
@@ -194,6 +194,18 @@ namespace taixia {
 #define TAIXIA_SWITCH(name) TAIXIA_ENTITY_(switch_::Switch, name)
 #define TAIXIA_TEXT_SENSOR(name) TAIXIA_ENTITY_(text_sensor::TextSensor, name)
 
+struct service_info_st {
+  uint8_t id;
+  int8_t min;
+  int8_t max;
+};
+
+#define SUPPORTED_SERVICES_INDEX_MIN  0
+#define SUPPORTED_SERVICES_INDEX_MAX  60
+
+#define SERVICE_ID(x) (uint8_t)(x & 0x7f)
+#define SERVICE_ID_WRITE(x) (bool)((x & WRITE) > 0)
+
 using response_parser_t = std::function<float(std::vector<uint8_t> &)>;
 
 class TaiXia;
@@ -242,6 +254,8 @@ class TaiXia : public uart::UARTDevice, public Component {
   bool read_sa_status();
 
   void power_switch(bool state) { this->power_switch_->publish_state(state); }
+
+  int8_t get_supported_service_info_(uint8_t service_id, int8_t* min, int8_t* max, bool* read_only);
 
   // TaiXIA
   TAIXIA_BINARY_SENSOR(power_binary_sensor)
@@ -312,6 +326,8 @@ class TaiXia : public uart::UARTDevice, public Component {
   void get_info_(void);
   bool read_climate_status_(void);
 
+  service_info_st supported_services_[SUPPORTED_SERVICES_INDEX_MAX];
+  bool supported_services_array_is_sorted_{true};
   std::vector<uint8_t> buffer_;
   uint8_t protocol_;
   uint8_t sa_id_;
@@ -320,7 +336,6 @@ class TaiXia : public uart::UARTDevice, public Component {
   uint16_t max_length_{0};
   uint32_t response_time_{1};
   bool have_sensors_{false};
-
   std::vector<TaiXiaListener *> listeners_{};
 
   bool write_command_(const uint8_t *command, uint8_t *response, uint8_t len, uint8_t tlen, uint32_t timeout);


### PR DESCRIPTION
- Retain array of all services reported by appliance
- Add function to return information on whether service was reported to be available by the appliance `get_supported_service_info_()`
  - `#ifdef`ed out a more efficient algorithm to find `service_id` in the array of retained services, but figured that it might be a little too much for something as simple as this. An array of hashes might be even better, but ESPs do not have that much RAM.
- For swing modes from climate control:
  - Add check if service is supported before sending to appliance
- Commented out some logging that was used for debugging.
  