### PR TITLE
Update example configurations for ESPHome compatibility

### DIFF
--- a/climate-taiseia.yaml
+++ b/climate-taiseia.yaml
@@ -17,6 +17,8 @@ external_components:
 
 esp32:
   board: esp32dev
+  framework:
+    type: esp-idf
 
 wifi:
   ssid: !secret wifi_ssid
@@ -34,6 +36,7 @@ logger:
 api:
 
 ota:
+  - platform: esphome
 
 uart:
   id: uart_taixia
@@ -74,10 +77,8 @@ climate:
 number:
   - platform: taixia
     type: airconditioner
-    vertical_fan_speed:
-      name: "Vertical Fan Speed"
-    horizontal_fan_speed:
-      name: "Horizontal Fan Speed"
+    swing_vertical_level:
+      name: "Swing Vertical Level"
     off_timer:
       name: "Off Timer"
     on_timer:
@@ -92,6 +93,8 @@ select:
       name: "Fuzzy Mode"
     display_mode:
       name: "Display Mode"
+    swing_horizontal_level:
+      name: "Swing Horizontal Level"
 
 sensor:
   - platform: wifi_signal

--- a/esphome-taiseia.yaml
+++ b/esphome-taiseia.yaml
@@ -30,6 +30,7 @@ logger:
 api:
 
 ota:
+  - platform: esphome
 
 uart:
   id: uart_taixia
@@ -40,9 +41,9 @@ uart:
 binary_sensor:
   - platform: status
     name: "${upper_devicename} Status"
-  - platform: taixia
-    power:
-      name: "${upper_devicename} Power"
+  # - platform: taixia
+  #   power:
+  #     name: "${upper_devicename} Power"
 
 button:
   - platform: restart

--- a/examples/Daikin/airconditioner/climate-s21-s3-faikin.yaml
+++ b/examples/Daikin/airconditioner/climate-s21-s3-faikin.yaml
@@ -66,8 +66,7 @@ uart:
 
 # The base UART communication hub.
 daikin_s21:
-  tx_uart: s21_uart
-  rx_uart: s21_uart
+  uart: s21_uart
 #  debug_protocol: true
 
 climate:
@@ -75,10 +74,6 @@ climate:
     platform: daikin_s21
     visual:
       temperature_step: 1.0
-    supports_humidity: true
-    # Optional HA sensor used to alter setpoint.
-    room_temperature_sensor: room_temp  # See homeassistant sensor below
-    setpoint_interval: 300s
 #    has_presets: false
     supported_modes:
       - COOL

--- a/examples/Daikin/airconditioner/secrets.yaml
+++ b/examples/Daikin/airconditioner/secrets.yaml
@@ -1,0 +1,1 @@
+<<: !include ../../secrets.yaml

--- a/examples/Daikin/dehumidifier/duhumidifer-atom-lite.yaml
+++ b/examples/Daikin/dehumidifier/duhumidifer-atom-lite.yaml
@@ -14,7 +14,7 @@ esphome:
 esp32:
   board: m5stack-atom
   framework:
-    type: arduino
+    type: esp-idf
 
 external_components:
   - source: github://tsunglung/taixia@master
@@ -40,6 +40,7 @@ logger:
 api:
 
 ota:
+  - platform: esphome
 
 # web_server:
 
@@ -86,19 +87,16 @@ light:
   - platform: status_led
     id: status_light
     output: status_output
-  - platform: neopixelbus
+  - platform: esp32_rmt_led_strip
     id: esp32_rgb_led
     name: Status RGB LED
-    type: RGB
-    variant: 800KBPS
-    pin: 27
+    chipset: WS2812
+    pin: GPIO27
     num_leds: 1
+    rgb_order: RGB
     icon: mdi:led-outline
     entity_category: config
     restore_mode: ALWAYS_OFF
-    method:
-      type: esp32_rmt
-      channel: 0
 
 number:
   - platform: taixia
@@ -147,7 +145,7 @@ switch:
     id: status_led_switch
     optimistic: true
     on_turn_on:
-      - light.turn_on: 
+      - light.turn_on:
           id: esp32_rgb_led
           red: 100%
           green: 0%
@@ -155,7 +153,7 @@ switch:
           brightness: 30%
           transition_length: 50ms
     on_turn_off:
-      - light.turn_off: 
+      - light.turn_off:
           id: esp32_rgb_led
           transition_length: 50ms
 

--- a/examples/Daikin/dehumidifier/secrets.yaml
+++ b/examples/Daikin/dehumidifier/secrets.yaml
@@ -1,0 +1,1 @@
+<<: !include ../../secrets.yaml

--- a/examples/Hitachi/airconditioner/climate-atom-lite-ra-28hv1.yaml
+++ b/examples/Hitachi/airconditioner/climate-atom-lite-ra-28hv1.yaml
@@ -13,6 +13,8 @@ esphome:
 
 esp32:
   board: m5stack-atom
+  framework:
+    type: esp-idf
 
 external_components:
   - source: github://tsunglung/taixia@master
@@ -38,6 +40,7 @@ logger:
 api:
 
 ota:
+  - platform: esphome
 
 # web_server:
 
@@ -94,19 +97,16 @@ light:
   - platform: status_led
     id: status_light
     output: status_output
-  - platform: neopixelbus
+  - platform: esp32_rmt_led_strip
     id: esp32_rgb_led
     name: Status RGB LED
-    type: RGB
-    variant: 800KBPS
-    pin: 27
+    chipset: WS2812
+    pin: GPIO27
     num_leds: 1
+    rgb_order: RGB
     icon: mdi:led-outline
     entity_category: config
     restore_mode: ALWAYS_OFF
-    method:
-      type: esp32_rmt
-      channel: 0
 
 number:
   - platform: taixia
@@ -178,7 +178,7 @@ switch:
     # name: "Status LED Switch"
     optimistic: true
     on_turn_on:
-      - light.turn_on: 
+      - light.turn_on:
           id: esp32_rgb_led
           red: 100%
           green: 0%
@@ -186,7 +186,7 @@ switch:
           brightness: 30%
           transition_length: 50ms
     on_turn_off:
-      - light.turn_off: 
+      - light.turn_off:
           id: esp32_rgb_led
           transition_length: 50ms
 

--- a/examples/Hitachi/airconditioner/climate-atom-lite-rad-71np.yaml
+++ b/examples/Hitachi/airconditioner/climate-atom-lite-rad-71np.yaml
@@ -13,6 +13,8 @@ esphome:
 
 esp32:
   board: m5stack-atom
+  framework:
+    type: esp-idf
 
 external_components:
   - source: github://tsunglung/taixia@master
@@ -38,6 +40,7 @@ logger:
 api:
 
 ota:
+  - platform: esphome
 
 # web_server:
 
@@ -94,19 +97,16 @@ light:
   - platform: status_led
     id: status_light
     output: status_output
-  - platform: neopixelbus
+  - platform: esp32_rmt_led_strip
     id: esp32_rgb_led
     name: Status RGB LED
-    type: RGB
-    variant: 800KBPS
-    pin: 27
+    chipset: WS2812
+    pin: GPIO27
     num_leds: 1
+    rgb_order: RGB
     icon: mdi:led-outline
     entity_category: config
     restore_mode: ALWAYS_OFF
-    method:
-      type: esp32_rmt
-      channel: 0
 
 number:
   - platform: taixia
@@ -178,7 +178,7 @@ switch:
     # name: "Status LED Switch"
     optimistic: true
     on_turn_on:
-      - light.turn_on: 
+      - light.turn_on:
           id: esp32_rgb_led
           red: 100%
           green: 0%
@@ -186,7 +186,7 @@ switch:
           brightness: 30%
           transition_length: 50ms
     on_turn_off:
-      - light.turn_off: 
+      - light.turn_off:
           id: esp32_rgb_led
           transition_length: 50ms
 

--- a/examples/Hitachi/airconditioner/climate-faikin-rad-36nt.yaml
+++ b/examples/Hitachi/airconditioner/climate-faikin-rad-36nt.yaml
@@ -14,6 +14,8 @@ esphome:
 esp32:
   board: m5stack-atom
   variant: esp32
+  framework:
+    type: esp-idf
 
 external_components:
   - source: github://tsunglung/taixia@master

--- a/examples/Hitachi/airconditioner/climate-faikin-rad-63nk.yaml
+++ b/examples/Hitachi/airconditioner/climate-faikin-rad-63nk.yaml
@@ -27,8 +27,7 @@ esp32:
   board: esp32-s3-devkitc-1
   variant: esp32s3
   framework:
-    type: arduino
-    version: 2.0.6
+    type: esp-idf
 
 wifi:
   ssid: !secret wifi_ssid
@@ -50,15 +49,16 @@ logger:
 api:
 
 ota:
+  - platform: esphome
 
 #web_server:
 
 uart:
   id: uart_taixia
-  tx_pin: 
+  tx_pin:
     number: GPIO48
     inverted: true
-  rx_pin: 
+  rx_pin:
     number: GPIO34
     inverted: true
   baud_rate: 9600
@@ -126,19 +126,12 @@ light:
     pin: GPIO47
     num_leds: 3
     rgb_order: GRB
-    rmt_channel: 0
     id: s3_wled
     name: "RGB LED"
 
 number:
   - platform: taixia
     type: airconditioner
-#    vertical_fan_speed:
-#      name: "Vertical Fan Speed"
-#      max_value: 4
-    horizontal_fan_speed:
-      name: "Horizontal Fan Speed"
-      max_value: 4
     off_timer:
       name: "Off Timer"
     on_timer:
@@ -149,6 +142,8 @@ select:
     type: airconditioner
     display_mode:
       name: "Display Mode"
+    swing_horizontal_level:
+      name: "Swing Horizontal Level"
 
 sensor:
   - platform: wifi_signal

--- a/examples/Hitachi/airconditioner/climate-faikin-rad-71njp.yaml
+++ b/examples/Hitachi/airconditioner/climate-faikin-rad-71njp.yaml
@@ -23,8 +23,7 @@ esp32:
   board: esp32-s3-devkitc-1
   variant: esp32s3
   framework:
-    type: arduino
-    version: 2.0.6
+    type: esp-idf
 
 external_components:
   - source: github://tsunglung/taixia@master
@@ -50,15 +49,16 @@ logger:
 api:
 
 ota:
+  - platform: esphome
 
 web_server:
 
 uart:
   id: uart_taixia
-  tx_pin: 
+  tx_pin:
     number: GPIO48
     inverted: true
-  rx_pin: 
+  rx_pin:
     number: GPIO34
     inverted: true
   baud_rate: 9600
@@ -112,7 +112,6 @@ light:
     pin: GPIO47
     num_leds: 3
     rgb_order: GRB
-    rmt_channel: 0
     id: s3_wled
     name: "RGB LED"
 

--- a/examples/Hitachi/airconditioner/climate-faikin-ras-22nk1.yaml
+++ b/examples/Hitachi/airconditioner/climate-faikin-ras-22nk1.yaml
@@ -27,8 +27,7 @@ esp32:
   board: esp32-s3-devkitc-1
   variant: esp32s3
   framework:
-    type: arduino
-    version: 2.0.6
+    type: esp-idf
 
 wifi:
   ssid: !secret wifi_ssid
@@ -50,15 +49,16 @@ logger:
 api:
 
 ota:
+  - platform: esphome
 
 #web_server:
 
 uart:
   id: uart_taixia
-  tx_pin: 
+  tx_pin:
     number: GPIO48
     inverted: true
-  rx_pin: 
+  rx_pin:
     number: GPIO34
     inverted: true
   baud_rate: 9600
@@ -127,19 +127,12 @@ light:
     pin: GPIO47
     num_leds: 3
     rgb_order: GRB
-    rmt_channel: 0
     id: s3_wled
     name: "RGB LED"
 
 number:
   - platform: taixia
     type: airconditioner
-#    vertical_fan_speed:
-#      name: "Vertical Fan Speed"
-#      max_value: 4
-    horizontal_fan_speed:
-      name: "Horizontal Fan Speed"
-      max_value: 4
     sleep_timer:
       name: "Sleep Timer"
     off_timer:
@@ -152,6 +145,8 @@ select:
     type: airconditioner
     display_mode:
       name: "Display Mode"
+    swing_horizontal_level:
+      name: "Swing Horizontal Level"
 
 sensor:
   - platform: wifi_signal
@@ -190,7 +185,7 @@ switch:
       name: "Buzzer"
     mildew_proof:
       name: "Mildew Proof"
-    air_flow_vertical:
+    swing_vertical:
       name: "Vertical Fan"
 
 text_sensor:

--- a/examples/Hitachi/airconditioner/climate-faikin-ras-28hqk.yaml
+++ b/examples/Hitachi/airconditioner/climate-faikin-ras-28hqk.yaml
@@ -27,8 +27,7 @@ esp32:
   board: esp32-s3-devkitc-1
   variant: esp32s3
   framework:
-    type: arduino
-    version: 2.0.6
+    type: esp-idf
 
 wifi:
   ssid: !secret wifi_ssid
@@ -50,15 +49,16 @@ logger:
 api:
 
 ota:
+  - platform: esphome
 
 #web_server:
 
 uart:
   id: uart_taixia
-  tx_pin: 
+  tx_pin:
     number: GPIO48
     inverted: true
-  rx_pin: 
+  rx_pin:
     number: GPIO34
     inverted: true
   baud_rate: 9600
@@ -126,7 +126,6 @@ light:
     pin: GPIO47
     num_leds: 3
     rgb_order: GRB
-    rmt_channel: 0
     id: s3_wled
     name: "RGB LED"
 
@@ -136,9 +135,6 @@ number:
 #    vertical_fan_speed:
 #      name: "Vertical Fan Speed"
 #      max_value: 4
-    horizontal_fan_speed:
-      name: "Horizontal Fan Speed"
-      max_value: 4
     off_timer:
       name: "Off Timer"
     on_timer:
@@ -149,6 +145,8 @@ select:
     type: airconditioner
     display_mode:
       name: "Display Mode"
+    swing_horizontal_level:
+      name: "Swing Horizontal Level"
 
 sensor:
   - platform: wifi_signal

--- a/examples/Hitachi/airconditioner/climate-faikin-ras-36njp.yaml
+++ b/examples/Hitachi/airconditioner/climate-faikin-ras-36njp.yaml
@@ -27,8 +27,7 @@ esp32:
   board: esp32-s3-devkitc-1
   variant: esp32s3
   framework:
-    type: arduino
-    version: 2.0.6
+    type: esp-idf
 
 wifi:
   ssid: !secret wifi_ssid
@@ -50,15 +49,16 @@ logger:
 api:
 
 ota:
+  - platform: esphome
 
 #web_server:
 
 uart:
   id: uart_taixia
-  tx_pin: 
+  tx_pin:
     number: GPIO48
     inverted: true
-  rx_pin: 
+  rx_pin:
     number: GPIO34
     inverted: true
   baud_rate: 9600
@@ -127,7 +127,6 @@ light:
     pin: GPIO47
     num_leds: 3
     rgb_order: GRB
-    rmt_channel: 0
     id: s3_wled
     name: "RGB LED"
 
@@ -137,9 +136,6 @@ number:
 #    vertical_fan_speed:
 #      name: "Vertical Fan Speed"
 #      max_value: 4
-    horizontal_fan_speed:
-      name: "Horizontal Fan Speed"
-      max_value: 4
     off_timer:
       name: "Off Timer"
     on_timer:
@@ -150,6 +146,8 @@ select:
     type: airconditioner
     display_mode:
       name: "Display Mode"
+    swing_horizontal_level:
+      name: "Swing Horizontal Level"
 
 sensor:
   - platform: wifi_signal

--- a/examples/Hitachi/airconditioner/climate-ultron.yaml
+++ b/examples/Hitachi/airconditioner/climate-ultron.yaml
@@ -17,6 +17,8 @@ external_components:
 
 esp32:
   board: esp32dev
+  framework:
+    type: esp-idf
 
 wifi:
   ssid: !secret wifi_ssid
@@ -38,6 +40,7 @@ logger:
 api:
 
 ota:
+  - platform: esphome
 
 #web_server:
 
@@ -124,12 +127,6 @@ light:
 number:
   - platform: taixia
     type: airconditioner
-    vertical_fan_speed:
-      name: "Vertical Fan Speed"
-      max_value: 4
-    horizontal_fan_speed:
-      name: "Horizontal Fan Speed"
-      max_value: 4
     off_timer:
       name: "Off Timer"
     on_timer:
@@ -151,6 +148,8 @@ select:
     type: airconditioner
     display_mode:
       name: "Display Mode"
+    swing_horizontal_level:
+      name: "Swing Horizontal Level"
 
 sensor:
   - platform: wifi_signal

--- a/examples/Hitachi/airconditioner/secrets.yaml
+++ b/examples/Hitachi/airconditioner/secrets.yaml
@@ -1,0 +1,1 @@
+<<: !include ../../secrets.yaml

--- a/examples/Hitachi/dehumidifier/dehumidifier-atom-lite.yaml
+++ b/examples/Hitachi/dehumidifier/dehumidifier-atom-lite.yaml
@@ -14,7 +14,7 @@ esphome:
 esp32:
   board: m5stack-atom
   framework:
-    type: arduino
+    type: esp-idf
 
 external_components:
   - source: github://tsunglung/taixia@master
@@ -40,6 +40,7 @@ logger:
 api:
 
 ota:
+  - platform: esphome
 
 # web_server:
 
@@ -109,19 +110,16 @@ light:
   - platform: status_led
     id: status_light
     output: status_output
-  - platform: neopixelbus
+  - platform: esp32_rmt_led_strip
     id: esp32_rgb_led
     name: Status RGB LED
-    type: RGB
-    variant: 800KBPS
-    pin: 27
+    chipset: WS2812
+    pin: GPIO27
     num_leds: 1
+    rgb_order: RGB
     icon: mdi:led-outline
     entity_category: config
     restore_mode: ALWAYS_OFF
-    method:
-      type: esp32_rmt
-      channel: 0
 
 number:
   - platform: taixia
@@ -234,7 +232,7 @@ switch:
     # name: "Status LED Switch"
     optimistic: true
     on_turn_on:
-      - light.turn_on: 
+      - light.turn_on:
           id: esp32_rgb_led
           red: 100%
           green: 0%
@@ -242,7 +240,7 @@ switch:
           brightness: 30%
           transition_length: 50ms
     on_turn_off:
-      - light.turn_off: 
+      - light.turn_off:
           id: esp32_rgb_led
           transition_length: 50ms
 

--- a/examples/Hitachi/dehumidifier/dehumidifier-faikin-rd-240hh.yaml
+++ b/examples/Hitachi/dehumidifier/dehumidifier-faikin-rd-240hh.yaml
@@ -23,8 +23,7 @@ esp32:
   board: esp32-s3-devkitc-1
   variant: esp32s3
   framework:
-    type: arduino
-    version: 2.0.6
+    type: esp-idf
 
 external_components:
   - source: github://tsunglung/taixia@master
@@ -48,13 +47,14 @@ logger:
 api:
 
 ota:
+  - platform: esphome
 
 uart:
   id: uart_taixia
-  tx_pin: 
+  tx_pin:
     number: GPIO48
     inverted: true
-  rx_pin: 
+  rx_pin:
     number: GPIO34
     inverted: true
   baud_rate: 9600
@@ -126,7 +126,6 @@ light:
     pin: GPIO47
     num_leds: 3
     rgb_order: GRB
-    rmt_channel: 0
     id: s3_wled
     name: "RGB LED"
 

--- a/examples/Hitachi/dehumidifier/dehumidifier-luatOS-c3.yaml
+++ b/examples/Hitachi/dehumidifier/dehumidifier-luatOS-c3.yaml
@@ -35,6 +35,8 @@ external_components:
 esp32:
   board: esp32-c3-devkitm-1
   variant: esp32c3
+  framework:
+    type: esp-idf
 
 wifi:
   ssid: !secret wifi_ssid
@@ -54,6 +56,7 @@ logger:
 api:
 
 ota:
+  - platform: esphome
 
 #web_server:
 
@@ -104,7 +107,7 @@ fan:
     speed_count: 4
     preset_modes:
 #      - auto
-      - normal 
+      - normal
       - home
       - boost
 #      - home
@@ -167,10 +170,10 @@ select:
     operating_program:
       name: "Operation Mode"
       options:
-        - normal 
+        - normal
         - boost
         - sleep
-        - home 
+        - home
         - eco
 
 sensor:

--- a/examples/Hitachi/dehumidifier/secrets.yaml
+++ b/examples/Hitachi/dehumidifier/secrets.yaml
@@ -1,0 +1,1 @@
+<<: !include ../../secrets.yaml

--- a/examples/Hitachi/erv/erv-taiseia-atom-lite.yaml
+++ b/examples/Hitachi/erv/erv-taiseia-atom-lite.yaml
@@ -60,9 +60,9 @@ binary_sensor:
   - platform: taixia
     type: erv
     filter_notify:
-      name: "Filter Notify
+      name: "Filter Notify"
     front_filter_notify:
-      name: "Front Filter Notify
+      name: "Front Filter Notify"
     pm25_filter_notify:
       name: "PM2.5 Filter Notify"
 
@@ -79,10 +79,10 @@ button:
     type: erv
     get_info:
       name: "Get Info"
-    filter_notify:
-      name: "Reset Filter Notify
+    filter_clean_notify:
+      name: "Reset Filter Notify"
     front_filter_notify:
-      name: "Rest Front Filter Notify
+      name: "Rest Front Filter Notify"
     pm25_filter_notify:
       name: "Rest PM2.5 Filter Notify"
 

--- a/examples/Hitachi/erv/erv-taiseia-faikin-s3.yaml
+++ b/examples/Hitachi/erv/erv-taiseia-faikin-s3.yaml
@@ -18,8 +18,7 @@ esp32:
   board: esp32-s3-devkitc-1
   variant: esp32s3
   framework:
-    type: arduino
-    version: 2.0.6
+    type: esp-idf
 
 external_components:
   - source: github://tsunglung/taixia@master

--- a/examples/Hitachi/erv/secrets.yaml
+++ b/examples/Hitachi/erv/secrets.yaml
@@ -1,0 +1,1 @@
+<<: !include ../../secrets.yaml

--- a/examples/Panasonic/airconditioner/climate-faikin-px-09310a19.yaml
+++ b/examples/Panasonic/airconditioner/climate-faikin-px-09310a19.yaml
@@ -23,8 +23,7 @@ esp32:
   board: esp32-s3-devkitc-1
   variant: esp32s3
   framework:
-    type: arduino
-    version: 2.0.6
+    type: esp-idf
 
 external_components:
   - source: github://tsunglung/taixia@master
@@ -50,15 +49,16 @@ logger:
 api:
 
 ota:
+  - platform: esphome
 
 web_server:
 
 uart:
   id: uart_taixia
-  tx_pin: 
+  tx_pin:
     number: GPIO48
     inverted: true
-  rx_pin: 
+  rx_pin:
     number: GPIO34
     inverted: true
   baud_rate: 9600
@@ -114,7 +114,6 @@ light:
     pin: GPIO47
     num_leds: 3
     rgb_order: GRB
-    rmt_channel: 0
     id: s3_wled
     name: "RGB LED"
 

--- a/examples/Panasonic/airconditioner/climate-faikin-px-12380a1d.yaml
+++ b/examples/Panasonic/airconditioner/climate-faikin-px-12380a1d.yaml
@@ -55,10 +55,10 @@ web_server:
 
 uart:
   id: uart_taixia
-  tx_pin: 
+  tx_pin:
     number: GPIO48
     inverted: true
-  rx_pin: 
+  rx_pin:
     number: GPIO34
     inverted: true
   baud_rate: 9600
@@ -108,7 +108,6 @@ light:
     pin: GPIO47
     num_leds: 3
     rgb_order: GRB
-    rmt_channel: 0
     id: s3_wled
     name: "RGB LED"
 
@@ -121,10 +120,14 @@ number:
 #      name: "On Timer"
     swing_vertical_level:
       name: "Swing Vertical Level"
-    swing_horizontal_level:
-      name: "Swing Horizontal Level"
+
+select:
+  - platform: taixia
+    type: airconditioner
     display_mode:
       name: "Display Mode"
+    swing_horizontal_level:
+      name: "Swing Horizontal Level"
 
 sensor:
   - platform: wifi_signal

--- a/examples/Panasonic/airconditioner/climate-faikin-rx-21360a0b.yaml
+++ b/examples/Panasonic/airconditioner/climate-faikin-rx-21360a0b.yaml
@@ -22,8 +22,7 @@ esp32:
   board: esp32-s3-devkitc-1
   variant: esp32s3
   framework:
-    type: arduino
-    version: 2.0.6
+    type: esp-idf
 
 external_components:
   - source: github://tsunglung/taixia@master
@@ -49,16 +48,16 @@ logger:
 api:
 
 ota:
-  platform: esphome
+  - platform: esphome
 
 web_server:
 
 uart:
   id: uart_taixia
-  tx_pin: 
+  tx_pin:
     number: GPIO48
     inverted: true
-  rx_pin: 
+  rx_pin:
     number: GPIO34
     inverted: true
   baud_rate: 9600
@@ -115,7 +114,6 @@ light:
     pin: GPIO47
     num_leds: 3
     rgb_order: GRB
-    rmt_channel: 0
     id: s3_wled
     name: "RGB LED"
 
@@ -124,12 +122,16 @@ number:
     type: airconditioner
     off_timer:
       name: "Off Timer"
-    vertical_fan_speed:
-      name: "Vertical Fan Speed"
-    horizontal_fan_speed:
-      name: "Horizontal Fan Speed"
+    swing_vertical_level:
+      name: "Swing Vertical Level"
 #    on_timer:
 #      name: "On Timer"
+
+select:
+  - platform: taixia
+    type: airconditioner
+    swing_horizontal_level:
+      name: "Swing Horizontal Level"
 
 sensor:
   - platform: wifi_signal

--- a/examples/Panasonic/airconditioner/secrets.yaml
+++ b/examples/Panasonic/airconditioner/secrets.yaml
@@ -1,0 +1,1 @@
+<<: !include ../../secrets.yaml

--- a/examples/Panasonic/dehumidifier/dehumidifier-atom-lite-fytw-08810115.yaml
+++ b/examples/Panasonic/dehumidifier/dehumidifier-atom-lite-fytw-08810115.yaml
@@ -104,19 +104,16 @@ light:
   - platform: status_led
     id: status_light
     output: status_output
-  - platform: neopixelbus
+  - platform: esp32_rmt_led_strip
+    chipset: WS2812
     id: esp32_rgb_led
     name: Status RGB LED
-    type: RGB
-    variant: 800KBPS
-    pin: 27
+    pin: GPIO27
     num_leds: 1
+    rgb_order: RGB
     icon: mdi:led-outline
     entity_category: config
     restore_mode: ALWAYS_OFF
-    method:
-      type: esp32_rmt
-      channel: 0
 
 number:
   - platform: taixia
@@ -180,8 +177,8 @@ switch:
     type: dehumidifier
     power:
       name: "Power Switch"
-    air_purfifier:
-      name: "Air Purfifier"
+    air_purifier:
+      name: "Air Purifier"
     beeper:
       name: "Beeper"
 
@@ -190,7 +187,7 @@ switch:
     # name: "Status LED Switch"
     optimistic: true
     on_turn_on:
-      - light.turn_on: 
+      - light.turn_on:
           id: esp32_rgb_led
           red: 100%
           green: 0%
@@ -198,7 +195,7 @@ switch:
           brightness: 30%
           transition_length: 50ms
     on_turn_off:
-      - light.turn_off: 
+      - light.turn_off:
           id: esp32_rgb_led
           transition_length: 50ms
 

--- a/examples/Panasonic/dehumidifier/secrets.yaml
+++ b/examples/Panasonic/dehumidifier/secrets.yaml
@@ -1,0 +1,1 @@
+<<: !include ../../secrets.yaml

--- a/examples/secrets.yaml
+++ b/examples/secrets.yaml
@@ -1,0 +1,3 @@
+# Your Wi-Fi SSID and password
+wifi_ssid: "YOUR_SSID_HERE"
+wifi_password: "YOUR_PASSWORD_HERE"

--- a/fan-taiseia.yaml
+++ b/fan-taiseia.yaml
@@ -17,6 +17,8 @@ external_components:
 
 esp32:
   board: esp32dev
+  framework:
+    type: esp-idf
 
 wifi:
   ssid: !secret wifi_ssid
@@ -34,6 +36,7 @@ logger:
 api:
 
 ota:
+  - platform: esphome
 
 uart:
   id: uart_taixia


### PR DESCRIPTION
Modernize all example YAML configurations to work with current ESPHome versions:
- Add esp-idf framework specification for ESP32 devices
- Update OTA configuration to new platform syntax
- Migrate neopixelbus to esp32_rmt_led_strip for LED control
- Standardize secrets management with centralized include files
- Fix deprecated Daikin S21 UART configuration
- Correct component names and typos (air_purifier, swing_vertical, etc.)
- Convert horizontal swing controls from number to select type
- Remove obsolete RMT channel specifications