### PR TITLE
Make UART receive non-blocking to fix watchdog resets and frame misalignment

### DIFF
--- a/components/taixia/taixia.cpp
+++ b/components/taixia/taixia.cpp
@@ -8,6 +8,16 @@ namespace taixia {
 static const char *const TAG = "taixia";
 static const uint8_t RESPONSE_LENGTH = 255;
 
+// Framing limits for the non-blocking receiver in loop().
+static const uint8_t MIN_FRAME_LENGTH = 6;
+static const uint8_t MAX_FRAME_LENGTH = 200;
+// Hard cap on the accumulation buffer. A full appliance status response is
+// ~115 bytes, so this leaves ample room for a partial frame plus a queued one.
+static const size_t RX_BUFFER_MAX = 512;
+// If a frame stays incomplete for this long, treat it as truncated and
+// resynchronise rather than waiting for bytes that will never arrive.
+static const uint32_t RX_STALE_MS = 250;
+
   void TaiXia::dump_config() {
     ESP_LOGCONFIG(TAG, "TaiXIA:");
     ESP_LOGCONFIG(TAG, "    SA_ID: %x", this->sa_id_);
@@ -424,12 +434,69 @@ static const uint8_t RESPONSE_LENGTH = 255;
       }
   }
 
+  // Non-blocking receiver.
+  //
+  // The previous implementation called readline() in a loop, which used
+  // read_array() to wait for a whole frame to arrive. A full status response is
+  // 115 bytes; at 9600 baud that takes ~120ms, but read_array()'s timeout is
+  // hard-coded to 100ms and consumes nothing when it expires. Every poll
+  // therefore blocked the main loop for seconds and left the stream misaligned,
+  // so the next iteration read a byte from the middle of a frame and mistook it
+  // for a length. With only a 1-byte XOR checksum, roughly 1 in 256 of those
+  // misaligned frames passed validation and fed garbage to the listeners.
+  //
+  // Instead, drain whatever the UART already holds, then parse only complete
+  // frames. An incomplete frame is left for the next loop() call rather than
+  // waited on, so this never blocks.
   void TaiXia::loop() {
-    if (!available())
-      return;
+    const uint32_t now = millis();
+    uint8_t c;
 
-    while (available()) {
-      readline(true);
+    while (this->available() && this->rx_.size() < RX_BUFFER_MAX) {
+      if (!this->read_byte(&c))
+        break;
+      this->rx_.push_back(c);
+      this->rx_last_byte_ms_ = now;
+    }
+
+    // Should not happen in practice; drop everything and resynchronise.
+    if (this->rx_.size() >= RX_BUFFER_MAX) {
+      ESP_LOGW(TAG, "RX buffer overflow, discarding %u bytes", (unsigned) this->rx_.size());
+      this->rx_.clear();
+      return;
+    }
+
+    while (!this->rx_.empty()) {
+      const uint8_t len = this->rx_[0];
+
+      // Implausible length: this byte cannot be a frame start.
+      if (len < MIN_FRAME_LENGTH || len > MAX_FRAME_LENGTH) {
+        this->rx_.erase(this->rx_.begin());
+        continue;
+      }
+
+      if (this->rx_.size() < len) {
+        // Still arriving. Wait for the next loop() unless the stream has gone
+        // quiet, in which case this is a truncated frame and we resynchronise.
+        if (now - this->rx_last_byte_ms_ > RX_STALE_MS)
+          this->rx_.erase(this->rx_.begin());
+        break;
+      }
+
+      // The checksum is the XOR of the whole frame including the length byte,
+      // i.e. XOR of the first len-1 bytes equals the last one.
+      if (this->checksum(this->rx_.data(), len - 1) == this->rx_[len - 1]) {
+        this->buffer_.assign(this->rx_.begin(), this->rx_.begin() + len);
+        for (auto &listener : this->listeners_)
+          listener->on_response(this->sa_id_, this->buffer_);
+        this->buffer_.clear();
+        this->rx_.erase(this->rx_.begin(), this->rx_.begin() + len);
+      } else {
+        // Most likely misalignment rather than corruption, so advance by a
+        // single byte. Dropping the whole candidate frame would skip past the
+        // real start of the next one.
+        this->rx_.erase(this->rx_.begin());
+      }
     }
   }
 

--- a/components/taixia/taixia.cpp
+++ b/components/taixia/taixia.cpp
@@ -452,9 +452,10 @@ static const uint32_t RX_STALE_MS = 250;
     const uint32_t now = millis();
     uint8_t c;
 
-    while (this->available() && this->rx_.size() < RX_BUFFER_MAX) {
-      if (!this->read_byte(&c))
+    while (this->available() && (this->rx_.size() < RX_BUFFER_MAX)) {
+      if (!this->read_byte(&c)) {
         break;
+      }
       this->rx_.push_back(c);
       this->rx_last_byte_ms_ = now;
     }
@@ -469,7 +470,10 @@ static const uint32_t RX_STALE_MS = 250;
     while (!this->rx_.empty()) {
       const uint8_t len = this->rx_[0];
 
-      // Implausible length: this byte cannot be a frame start.
+      // Implausible length: this byte cannot be a frame start. Drop only this
+      // one byte. The rest of the buffer may already hold a complete frame, so
+      // clearing it would throw away valid data and leave the stream misaligned
+      // again -- the very failure this receiver exists to avoid.
       if (len < MIN_FRAME_LENGTH || len > MAX_FRAME_LENGTH) {
         this->rx_.erase(this->rx_.begin());
         continue;
@@ -478,8 +482,9 @@ static const uint32_t RX_STALE_MS = 250;
       if (this->rx_.size() < len) {
         // Still arriving. Wait for the next loop() unless the stream has gone
         // quiet, in which case this is a truncated frame and we resynchronise.
-        if (now - this->rx_last_byte_ms_ > RX_STALE_MS)
+        if (now - this->rx_last_byte_ms_ > RX_STALE_MS) {
           this->rx_.erase(this->rx_.begin());
+        }
         break;
       }
 

--- a/components/taixia/taixia.h
+++ b/components/taixia/taixia.h
@@ -332,6 +332,10 @@ class TaiXia : public uart::UARTDevice, public Component {
   bool read_climate_status_(void);
 
   std::vector<uint8_t> buffer_;
+  // Accumulation buffer for the non-blocking receiver in loop(); holds bytes
+  // that have arrived but do not yet form a complete frame.
+  std::vector<uint8_t> rx_;
+  uint32_t rx_last_byte_ms_{0};
   uint8_t protocol_;
   uint8_t sa_id_;
   float version_{4.0};


### PR DESCRIPTION
## Problem

On an ESP32 with a full sensor set, two symptoms appear:

1. **The main loop blocks for 4.2–4.6 s per poll.** On ESPHome 2026.7+ this causes the device to be reset by the task watchdog at random intervals between 40 seconds and 26 minutes. (2026.7 changed the watchdog feed interval from a fixed 3 ms to 1/5 of the task WDT timeout — 1000 ms at the 5 s default — so the effective margin now fluctuates between 4.0 s and 5.0 s, which straddles the blocking time.)

2. **Spurious state changes.** The power switch and other states flip when the appliance has not changed. Measured at 2–50 false transitions per 48 hours per unit across four units.

## Root cause

`TaiXia::loop()` calls `readline()` repeatedly, and `readline()` relies on `read_array()` to wait for a whole frame:

```cpp
read_byte(&c);              // length byte consumed here
this->len_ = c;
len = this->len_ - 1;
read_array(response, len);  // blocks up to 100 ms, consumes nothing on timeout
```

A full status response is 115 bytes. At 9600 baud that takes **~120 ms**, but `read_array()`'s timeout is hard-coded to **100 ms** in `uart_component.cpp` and consumes nothing when it expires.

So every poll blocks, *and* leaves the stream misaligned — the length byte was already consumed by `read_byte()`, but the payload is still sitting in the buffer. The next iteration reads a byte from the middle of a frame and treats it as a length. Since the checksum is a single XOR byte, roughly **1 in 256** of those misaligned frames validates and delivers garbage to the listeners.

Both symptoms come from this one defect.

### Relation to #18

I think this also explains the invalid temperatures reported in #18, which I ran into on all four of my units.

The discussion there reasonably assumed that the per-frame checksum ruled out corrupted or truncated responses. That holds for corruption *within* a correctly framed response, but not for misalignment: once the stream is offset, the receiver is reading a window that spans two real frames, and the "checksum" it validates is just one arbitrary byte of payload. A single XOR byte collides about 1 time in 256, so at the frame rate this component polls at, garbage gets through regularly rather than rarely.

That is consistent with `8377` = `0x20B9` recurring as the reported value. In the SA Services dump in #18 — which is a list of 3-byte entries — the byte pair `20 B9` occurs only as a straddle across two entries:

```
... AF 52 58 | B0 03 20 | B9 00 03 ...
                     ^^^^^
```

It is never a field value in its own right. A correctly framed parse cannot produce it; a parse offset by one byte can. (That dump is the services list rather than the status response the temperature comes from, so this is suggestive rather than proof — but the same off-by-one mechanism applies to both.)

Range-clamping the temperature is still worth having as a defence in depth, but on my units the misframing was the source, and it also produced out-of-range values on fields where a range check does not help (e.g. `current_temperature` reading `0`, and spurious `power_switch` transitions). After this patch all of them stopped, without any value filtering.

#16 (state jumping back after control) may have the same root, though I have not verified that specifically.

## Fix

Replace the blocking read with an accumulating framer. Drain only what the UART already holds, then parse only complete frames; leave a partial one for the next `loop()` call rather than waiting on it.

Two details worth noting:

- On checksum failure, advance by **one byte** rather than discarding the candidate frame — dropping the whole frame would skip past the real start of the next one.
- A stale-data timeout resynchronises after a genuinely truncated frame, and the buffer is capped as a safety net.

## Measurements

Four units — 2× RAS-71NTB (ESP32, `wemos_d1_mini32`) and 2× RAS-28NTB (ESP32-C3, `airm2m_core_esp32c3`), ESPHome 2026.7.3:

| | before | after |
|---|---|---|
| `loop_time` (debug component) | 4694 ms | 19–35 ms |
| CRC mismatches / 45 s | 101 | **0** |
| "Could not read response" / 45 s | 85 | **0** |
| UART timeouts / 45 s | 79 | **0** |
| Spurious `power_switch` transitions / 48 h | 39 / 50 / 33 / 2 | **0** |
| Time until sensors populate | ~48 s, intermittent | ~3 s, stable |
| Watchdog resets | every 40 s – 26 min | none |

A side effect: sensor values are now readable while the appliance is **off** (previously `current_temperature` read 0 until the unit was switched on).

## Compatibility

- `readline()` is unchanged. `get_info_()` still uses it and only runs on demand, so its one-off blocking is unaffected.
- The checksum logic is equivalent. The original `checksum(response, len-1) ^ (len+1)` expands to "XOR of the entire frame including the length byte is zero"; the new `checksum(rx_.data(), len-1) == rx_[len-1]` is the same expression.
- `len_` is only used inside `readline()`, so not setting it in `loop()` has no other effect.
- **Behaviour change:** `max_length` no longer affects the main receive path, since `loop()` no longer goes through `readline()`. It still applies to `get_info_()`. Its original purpose — capping the RX buffer to limit blocking — is obsolete once the receiver no longer blocks. I left the option in place rather than removing it, but you may want to deprecate it.

## Notes

I opened the same change against @djurny's fork as [djurny/taixia#1](https://github.com/djurny/taixia/pull/1), since that is the tree I run. Sending it here as well because the defect is in `master` and this seems like the right place for it. Happy to adjust either one — the patch applies cleanly to `master` as-is.
