### PR TITLE
Fix dehumidifier error_code sensor not being created

### DIFF
--- a/components/taixia/sensor/__init__.py
+++ b/components/taixia/sensor/__init__.py
@@ -605,6 +605,9 @@ async def to_code(config):
         if CONF_SIDE_AIR_VENT in config:
             sens = await sensor.new_sensor(config[CONF_SIDE_AIR_VENT])
             cg.add(var.set_side_air_vent_sensor(sens))
+        if CONF_ERROR_CODE in config:
+            sens = await sensor.new_sensor(config[CONF_ERROR_CODE])
+            cg.add(var.set_error_code_sensor(sens))
         if CONF_DEFROST in config:
             sens = await sensor.new_sensor(config[CONF_DEFROST])
             cg.add(var.set_defrost_sensor(sens))

--- a/components/taixia/sensor/taixia_sensor.h
+++ b/components/taixia/sensor/taixia_sensor.h
@@ -52,7 +52,7 @@ class DehumidifierSensor : public TaiXiaListener, public PollingComponent {
   void set_water_full_sensor(sensor::Sensor *sensor) { this->water_full_sensor_ = sensor; }
   void set_filter_clean_sensor(sensor::Sensor *sensor) { this->filter_clean_sensor_ = sensor; }
   void set_side_air_vent_sensor(sensor::Sensor *sensor) { this->side_air_vent_sensor_ = sensor; }
-  void set_error_code_sensor_(sensor::Sensor *sensor) { this->error_code_sensor_ = sensor; }
+  void set_error_code_sensor(sensor::Sensor *sensor) { this->error_code_sensor_ = sensor; }
   void set_operating_current_sensor(sensor::Sensor *sensor) { this->operating_current_sensor_ = sensor; }
   void set_operating_voltage_sensor(sensor::Sensor *sensor) { this->operating_voltage_sensor_ = sensor; }
   void set_operating_power_sensor(sensor::Sensor *sensor) { this->operating_power_sensor_ = sensor; }


### PR DESCRIPTION
## Problem

The dehumidifier's `error_code` sensor (service `0x12`) never gets created, even when it's listed in YAML under `sensor:`. The C++ side is already fully wired up (member variable and the `SERVICE_ID_DEHUMIDTFIER_ERROR_CODE` case in `handle_response()` both exist), but two Python-side issues prevent the entity from ever being registered.

## Root cause

1. `components/taixia/sensor/__init__.py`: the dehumidifier branch of `to_code()` is missing the block that turns `CONF_ERROR_CODE` config into a sensor + `set_error_code_sensor()` call. The schema accepts the `error_code` key so compilation doesn't fail, but the entity is silently never created. The climate branch already has the equivalent handling — the dehumidifier branch just doesn't.
2. `components/taixia/sensor/taixia_sensor.h`: `DehumidifierSensor`'s setter is named `set_error_code_sensor_` (trailing underscore), which doesn't match the naming convention of the other setters in the same class (e.g. `set_side_air_vent_sensor`). Fixing #1 alone would not compile without also fixing this.

## Fix

- Add the missing `if CONF_ERROR_CODE in config: ...` block to the dehumidifier branch in `sensor/__init__.py`, mirroring the existing pattern used for `side_air_vent`/`defrost`.
- Rename the setter to `set_error_code_sensor` (drop the extra underscore) to match the rest of the class and the call site added above.

## Testing

Tested on a real Hitachi ceiling-recessed dehumidifier (RDI-360DX) via a Simon IoT ST01 dehumidifier module. Before the fix, `error_code` in YAML compiled fine but the entity never appeared. After applying both changes and re-flashing, the entity is created successfully and reads `0` (no fault), matching the value independently confirmed via raw UART service `0x12`.